### PR TITLE
fix(events): add getHandlerList() method for AbstractMaxBansEvent

### DIFF
--- a/src/main/java/org/maxgamer/maxbans/event/AbstractMaxBansEvent.java
+++ b/src/main/java/org/maxgamer/maxbans/event/AbstractMaxBansEvent.java
@@ -10,4 +10,8 @@ public abstract class AbstractMaxBansEvent extends Event {
     public HandlerList getHandlers() {
         return HANDLERS;
     }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
 }


### PR DESCRIPTION
Bukkit(/Spigot) needs two methods for the classes that extends the Event class, a static getHandlerList and a non-static getHandlers.
This following exception was thrown when I tried to use the Event API of MaxBans.

> org.bukkit.plugin.IllegalPluginAccessException: Unable to find handler list for event org.maxgamer.maxbans.event.AbstractMaxBansEvent. Static getHandlerList method required!
